### PR TITLE
Adding time handling to existing date filter input for format_string

### DIFF
--- a/liquid_syntax/date.ml
+++ b/liquid_syntax/date.ml
@@ -17,8 +17,18 @@ let now_as_string fmat =
   formatted
 
 let format_date_string date_str fmat =
-  let date = Printer.Date.from_string date_str in
-  let formatted = Printer.Date.sprint fmat date in
+  let date =
+    try Printer.Calendar.from_fstring "%FT%T" date_str
+      (* ISO with T: "2026-03-06T15:09:00" *)
+    with Invalid_argument _ ->
+    try Printer.Calendar.from_fstring "%F %T" date_str
+      (* Space-separated: "2026-03-06 15:09:00" *)
+    with Invalid_argument _ ->
+      (* Date only: "2026-03-06", time defaults to 00:00:00 *)
+      let d = Printer.Date.from_string date_str in
+      Calendar.create d (Time.make 0 0 0)
+  in
+  let formatted = Printer.Calendar.sprint fmat date in
   formatted
 
 let as_string date fmat = Printer.Calendar.sprint fmat date

--- a/test/test_helper_filters.ml
+++ b/test/test_helper_filters.ml
@@ -65,6 +65,54 @@ let test_date_complex_format () =
   let result = render_text ~settings "{{ date_str | date: '%B %d, %Y' }}" in
   check string "date complex format" "January 15, 2025" result
 
+(* DateTime with time component tests *)
+
+let test_datetime_iso_format () =
+  let context =
+    Ctx.empty |> Ctx.add "date_str" (String "2026-03-06T15:09:00")
+  in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ date_str | date: '%Y%m%d-%H%M' }}" in
+  check string "datetime ISO format" "20260306-1509" result
+
+let test_datetime_iso_date_part () =
+  let context =
+    Ctx.empty |> Ctx.add "date_str" (String "2026-03-06T15:09:00")
+  in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ date_str | date: '%Y-%m-%d' }}" in
+  check string "datetime ISO date part only" "2026-03-06" result
+
+let test_datetime_iso_time_part () =
+  let context =
+    Ctx.empty |> Ctx.add "date_str" (String "2026-03-06T15:09:30")
+  in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ date_str | date: '%H:%M:%S' }}" in
+  check string "datetime ISO time part" "15:09:30" result
+
+let test_datetime_default_format () =
+  let context =
+    Ctx.empty |> Ctx.add "date_str" (String "2026-03-06T15:09:00")
+  in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ date_str | date }}" in
+  check string "datetime default format" "03/06/2026" result
+
+let test_date_only_time_defaults_midnight () =
+  let context = Ctx.empty |> Ctx.add "date_str" (String "2026-03-06") in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ date_str | date: '%Y%m%d-%H%M' }}" in
+  check string "date only time defaults midnight" "20260306-0000" result
+
+let test_datetime_space_separated () =
+  let context =
+    Ctx.empty |> Ctx.add "date_str" (String "2026-03-06 15:09:00")
+  in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ date_str | date: '%Y%m%d-%H%M' }}" in
+  check string "datetime space separated format" "20260306-1509" result
+
 let test_date_now_keyword () =
   let settings = Settings.make () in
   (* We can't test exact output for "now", but we can check it doesn't error *)
@@ -286,6 +334,13 @@ let suite =
     ; test_case "date weekday name" `Quick test_date_weekday_name
     ; test_case "date abbreviated weekday" `Quick test_date_abbreviated_weekday
     ; test_case "date complex format" `Quick test_date_complex_format
+    ; test_case "datetime ISO format" `Quick test_datetime_iso_format
+    ; test_case "datetime ISO date part" `Quick test_datetime_iso_date_part
+    ; test_case "datetime ISO time part" `Quick test_datetime_iso_time_part
+    ; test_case "datetime default format" `Quick test_datetime_default_format
+    ; test_case "date only time defaults midnight" `Quick
+        test_date_only_time_defaults_midnight
+    ; test_case "datetime space separated" `Quick test_datetime_space_separated
     ; test_case "date now keyword" `Quick test_date_now_keyword
     ; test_case "date now default format" `Quick test_date_now_default_format
       (* Default filter tests *)


### PR DESCRIPTION
Hi there! Apologies for the drive-by PR; no sweat if this isn't really what you're after :) 

I am using Liquid_ml with a little static-site generator/blog thing to learn Ocaml, it's awesome! One thing I came across though is that the `input | date` format seems to only accept `YYYY-MM-DD` in, so I can't pass it a timestamp without constructing a Calendar and feeding it in as String:
```ocaml
let date = CalendarLib.Printer.Calendar.from_fstring "%FT%T" post.meta.date in
Ctx.add "date" (Date date)
```
Now this is totally fine and again, probably what I'm expected to do here, but I thought I'd take a crack at adding time handling in for bare `String val`'s passed to Ctx and handed to the `| date` filter as well!

No expectation of this being merged or anything, I am _very_ new to OCaml too so apologies if my code is crap as well, but figured I'd send a PR through in case this was at all useful to anyone else