### PR TITLE
Fix dynamic array indexing hang and {% liquid tag with spaces

### DIFF
--- a/liquid_parser/lexer.ml
+++ b/liquid_parser/lexer.ml
@@ -119,8 +119,26 @@ let lex_id text =
           let folder acc m =
             let is_string = starts_with m "[\"" || starts_with m "['" in
             let pos = if is_string then 2 else 1 in
+            let inner = String.sub m ~pos ~len:(String.length m - (pos * 2)) in
+            let inner = String.strip inner in
+            let is_number =
+              String.length inner > 0
+              && String.for_all inner ~f:Char.is_digit
+            in
             let dot_notation =
-              "." ^ String.sub m ~pos ~len:(String.length m - (pos * 2))
+              if is_string || is_number then "." ^ inner
+              else
+                (* Dynamic expression inside brackets, e.g. l[forloop.index].
+                   Mark with sentinel so unwrap can resolve it from context
+                   instead of treating it as nested property access. The
+                   sentinel \x00 prefixes the piece; \x01 stands in for the
+                   dots inside the bracket expression so the outer split on
+                   '.' keeps the dynamic path together. *)
+                let escaped =
+                  String.map inner ~f:(fun c ->
+                      if Char.equal c '.' then '\x01' else c)
+                in
+                "." ^ "\x00" ^ escaped
             in
             String.substr_replace_first acc ~pattern:m ~with_:dot_notation
           in
@@ -152,7 +170,12 @@ let lex_block_token_chunk (chunk2, chunk3) acc index =
     Next (acc @ [ block_token_of_string chunk2 ], index + String.length chunk2)
   else
     match List.rev acc with
-    | RawText "liquid" :: StatementStart _ :: hds ->
+    | RawText tl :: StatementStart _ :: hds
+      when String.equal (String.strip tl) "liquid" ->
+        (* Accept `{% liquid`, `{%liquid`, `{%- liquid`, etc. The original
+           pattern only matched the exact RawText "liquid", which broke the
+           common case where there's whitespace between `{%` and the tag
+           name. *)
         Next (List.rev hds @ [ LiquidStart ], index + 1)
     | RawText tl :: hds ->
         Next (List.rev hds @ [ RawText (tl ^ first_letter chunk2) ], index + 1)

--- a/liquid_parser/lexer.ml
+++ b/liquid_parser/lexer.ml
@@ -128,12 +128,6 @@ let lex_id text =
             let dot_notation =
               if is_string || is_number then "." ^ inner
               else
-                (* Dynamic expression inside brackets, e.g. l[forloop.index].
-                   Mark with sentinel so unwrap can resolve it from context
-                   instead of treating it as nested property access. The
-                   sentinel \x00 prefixes the piece; \x01 stands in for the
-                   dots inside the bracket expression so the outer split on
-                   '.' keeps the dynamic path together. *)
                 let escaped =
                   String.map inner ~f:(fun c ->
                       if Char.equal c '.' then '\x01' else c)
@@ -172,10 +166,6 @@ let lex_block_token_chunk (chunk2, chunk3) acc index =
     match List.rev acc with
     | RawText tl :: StatementStart _ :: hds
       when String.equal (String.strip tl) "liquid" ->
-        (* Accept `{% liquid`, `{%liquid`, `{%- liquid`, etc. The original
-           pattern only matched the exact RawText "liquid", which broke the
-           common case where there's whitespace between `{%` and the tag
-           name. *)
         Next (List.rev hds @ [ LiquidStart ], index + 1)
     | RawText tl :: hds ->
         Next (List.rev hds @ [ RawText (tl ^ first_letter chunk2) ], index + 1)

--- a/liquid_syntax/values.ml
+++ b/liquid_syntax/values.ml
@@ -38,11 +38,6 @@ and unwrap_id ctx id =
   | [ id ] -> find ctx id
   | id -> unwrap_chain ctx id
 
-(* Bracket expressions like `l[forloop.index]` are tagged by the lexer with a
-   sentinel: the piece starts with '\x00' and dots inside it are encoded as
-   '\x01'. Before doing anything else with a Var, walk its pieces and replace
-   each dynamic piece with the literal value it resolves to in the current
-   context (numbers and strings become indices/keys). *)
 and resolve_dynamic_pieces ctx id =
   List.concat_map id ~f:(fun piece ->
       if String.length piece > 0 && Char.equal piece.[0] '\x00' then
@@ -86,22 +81,15 @@ and unwrap_chain ctx id =
         (nv, Ctx.empty |> Ctx.add hd nv)
     | v
       when List.mem [ "first"; "last"; "size" ] hd ~equal:String.equal ->
-        (* Method-style access on a non-object value (e.g. list.first). *)
         let nctx = Ctx.empty |> Ctx.add Settings.next v in
         let nv = unwrap nctx (Var [ Settings.next; hd ]) in
         (nv, nctx)
     | List lst when (
         match Int.of_string_opt hd with Some _ -> true | None -> false) ->
-        (* Numeric index against a list, e.g. after dynamic resolution turned
-           `[forloop.index]` into the index string. *)
         let idx = Int.of_string hd in
         let nv = unwrap_or (List.nth lst idx) Nil in
         (nv, Ctx.empty |> Ctx.add hd nv)
-    | _ ->
-        (* Unknown field on a non-object value. Returning Nil here keeps us
-           from infinitely recursing (the previous fallback re-entered unwrap
-           with the same shape and hung). *)
-        (Nil, acc_ctx)
+    | _ -> (Nil, acc_ctx)
   in
 
   let v, _ = List.fold id ~init:(Nil, ctx) ~f:folder in

--- a/liquid_syntax/values.ml
+++ b/liquid_syntax/values.ml
@@ -13,23 +13,56 @@ let is_index id =
       Re2.matches digit hd
   | _ -> false
 
-let rec unwrap ctx = function
-  | Var id when is_calling ctx id "first" ->
+let rec unwrap ctx v =
+  match v with
+  | Var id ->
+      let id = resolve_dynamic_pieces ctx id in
+      unwrap_id ctx id
+  | other -> other
+
+and unwrap_id ctx id =
+  match id with
+  | id when is_calling ctx id "first" ->
       let lst = unwrap_list ctx id in
       unwrap_or (List.hd lst) Nil
-  | Var id when is_calling ctx id "last" ->
+  | id when is_calling ctx id "last" ->
       let lst = unwrap_list ctx id in
       unwrap_or (List.last lst) Nil
-  | Var id when is_calling ctx id "size" ->
+  | id when is_calling ctx id "size" ->
       let lst = unwrap_list ctx id in
       Number (List.length lst |> Int.to_float)
-  | Var id when is_index id ->
+  | id when is_index id ->
       let index = id |> List.last_exn |> Int.of_string in
       let lst = unwrap_list ctx id in
       unwrap_or (List.nth lst index) Nil
-  | Var [ id ] -> find ctx id
-  | Var id -> unwrap_chain ctx id
-  | other -> other
+  | [ id ] -> find ctx id
+  | id -> unwrap_chain ctx id
+
+(* Bracket expressions like `l[forloop.index]` are tagged by the lexer with a
+   sentinel: the piece starts with '\x00' and dots inside it are encoded as
+   '\x01'. Before doing anything else with a Var, walk its pieces and replace
+   each dynamic piece with the literal value it resolves to in the current
+   context (numbers and strings become indices/keys). *)
+and resolve_dynamic_pieces ctx id =
+  List.concat_map id ~f:(fun piece ->
+      if String.length piece > 0 && Char.equal piece.[0] '\x00' then
+        let body =
+          String.sub piece ~pos:1 ~len:(String.length piece - 1)
+        in
+        let sub_pieces =
+          String.split body ~on:'\x01'
+          |> List.filter ~f:(fun s -> not (String.is_empty s))
+        in
+        match sub_pieces with
+        | [] -> [ "" ]
+        | _ -> (
+            match unwrap ctx (Var sub_pieces) with
+            | Number n -> [ Float.to_int n |> Int.to_string ]
+            | String s -> [ s ]
+            | Bool b -> [ Bool.to_string b ]
+            | Nil -> [ "" ]
+            | _ -> [ "" ])
+      else [ piece ])
 
 and unwrap_tail ctx v = Var (without_last v) |> unwrap ctx
 
@@ -51,10 +84,24 @@ and unwrap_chain ctx id =
     | Object obj ->
         let nv = unwrap_or (Object.find_opt hd obj) Nil in
         (nv, Ctx.empty |> Ctx.add hd nv)
-    | v ->
+    | v
+      when List.mem [ "first"; "last"; "size" ] hd ~equal:String.equal ->
+        (* Method-style access on a non-object value (e.g. list.first). *)
         let nctx = Ctx.empty |> Ctx.add Settings.next v in
         let nv = unwrap nctx (Var [ Settings.next; hd ]) in
         (nv, nctx)
+    | List lst when (
+        match Int.of_string_opt hd with Some _ -> true | None -> false) ->
+        (* Numeric index against a list, e.g. after dynamic resolution turned
+           `[forloop.index]` into the index string. *)
+        let idx = Int.of_string hd in
+        let nv = unwrap_or (List.nth lst idx) Nil in
+        (nv, Ctx.empty |> Ctx.add hd nv)
+    | _ ->
+        (* Unknown field on a non-object value. Returning Nil here keeps us
+           from infinitely recursing (the previous fallback re-entered unwrap
+           with the same shape and hung). *)
+        (Nil, acc_ctx)
   in
 
   let v, _ = List.fold id ~init:(Nil, ctx) ~f:folder in

--- a/test/test_for_loops.ml
+++ b/test/test_for_loops.ml
@@ -422,6 +422,54 @@ let test_for_loop_large_list () =
   let result = render_text ~settings template in
   check string "for loop with large list (limited)" "01234" result
 
+(* Regression tests for issue #8: using forloop.* as an array index used to
+   make the interpreter hang forever. *)
+
+let test_for_loop_index_dynamic_array_access () =
+  let items = List [ String "a"; String "b"; String "c" ] in
+  let context = Ctx.empty |> Ctx.add "items" items in
+  let settings = Settings.make ~context () in
+  let template =
+    "{% for item in items %}{{ items[forloop.index0] }}{% endfor %}"
+  in
+  let result = render_text ~settings template in
+  check string "items[forloop.index0]" "abc" result
+
+let test_for_loop_index1_dynamic_array_access () =
+  (* forloop.index is 1-based, so the last lookup is out of bounds (nil). *)
+  let items = List [ String "a"; String "b"; String "c" ] in
+  let context = Ctx.empty |> Ctx.add "items" items in
+  let settings = Settings.make ~context () in
+  let template =
+    "{% for item in items %}{{ items[forloop.index] }}{% endfor %}"
+  in
+  let result = render_text ~settings template in
+  check string "items[forloop.index]" "bcnil" result
+
+let test_dynamic_array_index_from_variable () =
+  let items = List [ String "x"; String "y"; String "z" ] in
+  let context =
+    Ctx.empty |> Ctx.add "items" items |> Ctx.add "i" (Number 1.0)
+  in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ items[i] }}" in
+  check string "items[i] with i from context" "y" result
+
+let test_dynamic_object_key_from_variable () =
+  let user =
+    Object.empty
+    |> Object.add "name" (String "Alice")
+    |> Object.add "age" (Number 30.0)
+  in
+  let context =
+    Ctx.empty
+    |> Ctx.add "user" (Object user)
+    |> Ctx.add "field" (String "name")
+  in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{{ user[field] }}" in
+  check string "user[field] dynamic object key" "Alice" result
+
 (* Test suite *)
 let suite =
   ( "For Loop Tests"
@@ -481,4 +529,13 @@ let suite =
     ; test_case "for loop with assign inside" `Quick
         test_for_loop_with_assign_inside
     ; test_case "for loop large list" `Quick test_for_loop_large_list
+    ; (* Regression tests for issue #8 (dynamic array/object access) *)
+      test_case "items[forloop.index0]" `Quick
+        test_for_loop_index_dynamic_array_access
+    ; test_case "items[forloop.index]" `Quick
+        test_for_loop_index1_dynamic_array_access
+    ; test_case "items[i] with variable index" `Quick
+        test_dynamic_array_index_from_variable
+    ; test_case "obj[field] dynamic key" `Quick
+        test_dynamic_object_key_from_variable
     ] )

--- a/test/test_for_loops.ml
+++ b/test/test_for_loops.ml
@@ -422,9 +422,6 @@ let test_for_loop_large_list () =
   let result = render_text ~settings template in
   check string "for loop with large list (limited)" "01234" result
 
-(* Regression tests for issue #8: using forloop.* as an array index used to
-   make the interpreter hang forever. *)
-
 let test_for_loop_index_dynamic_array_access () =
   let items = List [ String "a"; String "b"; String "c" ] in
   let context = Ctx.empty |> Ctx.add "items" items in
@@ -436,7 +433,6 @@ let test_for_loop_index_dynamic_array_access () =
   check string "items[forloop.index0]" "abc" result
 
 let test_for_loop_index1_dynamic_array_access () =
-  (* forloop.index is 1-based, so the last lookup is out of bounds (nil). *)
   let items = List [ String "a"; String "b"; String "c" ] in
   let context = Ctx.empty |> Ctx.add "items" items in
   let settings = Settings.make ~context () in
@@ -529,8 +525,7 @@ let suite =
     ; test_case "for loop with assign inside" `Quick
         test_for_loop_with_assign_inside
     ; test_case "for loop large list" `Quick test_for_loop_large_list
-    ; (* Regression tests for issue #8 (dynamic array/object access) *)
-      test_case "items[forloop.index0]" `Quick
+    ; test_case "items[forloop.index0]" `Quick
         test_for_loop_index_dynamic_array_access
     ; test_case "items[forloop.index]" `Quick
         test_for_loop_index1_dynamic_array_access

--- a/test/test_interpreter.ml
+++ b/test/test_interpreter.ml
@@ -462,8 +462,6 @@ let test_liquid_tag_no_space () =
   let result = render_text template in
   check string "{%liquid (no space)" "\nhello\nafter" result
 
-(* Regression test for issue #9: `{% liquid` (with a space between %% and
-   the tag name) should be recognized just like `{%liquid`. *)
 let test_liquid_tag_with_space () =
   let template =
     "{% liquid\nassign x = \"hello\"\necho x\n%}after"
@@ -547,7 +545,7 @@ let suite =
     ; test_case "style basic" `Quick test_style_basic
     ; test_case "style with liquid" `Quick test_style_with_liquid
     ; test_case "style empty" `Quick test_style_empty
-      (* Liquid tag tests (regression: issue #9) *)
+      (* Liquid tag tests *)
     ; test_case "{%liquid (no space)" `Quick test_liquid_tag_no_space
     ; test_case "{% liquid (with space)" `Quick test_liquid_tag_with_space
     ; test_case "{%   liquid (multiple spaces)" `Quick

--- a/test/test_interpreter.ml
+++ b/test/test_interpreter.ml
@@ -453,6 +453,38 @@ let test_style_empty () =
   let result = render_text ~settings "{% style %}{% endstyle %}" in
   check string "style empty" "<style data-liquid></style>" result
 
+(* Liquid tag tests *)
+
+let test_liquid_tag_no_space () =
+  let template =
+    "{%liquid\nassign x = \"hello\"\necho x\n%}after"
+  in
+  let result = render_text template in
+  check string "{%liquid (no space)" "\nhello\nafter" result
+
+(* Regression test for issue #9: `{% liquid` (with a space between %% and
+   the tag name) should be recognized just like `{%liquid`. *)
+let test_liquid_tag_with_space () =
+  let template =
+    "{% liquid\nassign x = \"hello\"\necho x\n%}after"
+  in
+  let result = render_text template in
+  check string "{% liquid (with space)" "\nhello\nafter" result
+
+let test_liquid_tag_with_multiple_spaces () =
+  let template =
+    "{%   liquid\nassign x = \"hello\"\necho x\n%}after"
+  in
+  let result = render_text template in
+  check string "{%   liquid (multiple spaces)" "\nhello\nafter" result
+
+let test_liquid_tag_with_trim_and_space () =
+  let template =
+    "prefix {%- liquid\nassign x = \"hello\"\necho x\n-%} after"
+  in
+  let result = render_text template in
+  check string "{%- liquid (trim + space)" "prefix \nhello\n after" result
+
 (* Test suite *)
 let suite =
   ( "Interpreter Tests"
@@ -515,4 +547,11 @@ let suite =
     ; test_case "style basic" `Quick test_style_basic
     ; test_case "style with liquid" `Quick test_style_with_liquid
     ; test_case "style empty" `Quick test_style_empty
+      (* Liquid tag tests (regression: issue #9) *)
+    ; test_case "{%liquid (no space)" `Quick test_liquid_tag_no_space
+    ; test_case "{% liquid (with space)" `Quick test_liquid_tag_with_space
+    ; test_case "{%   liquid (multiple spaces)" `Quick
+        test_liquid_tag_with_multiple_spaces
+    ; test_case "{%- liquid (trim + space)" `Quick
+        test_liquid_tag_with_trim_and_space
     ] )


### PR DESCRIPTION
Fixes #8 and #9.

## #8: `l[forloop.index]` causes the interpreter to hang

The lexer flattened `l[forloop.index]` into the same piece list as `l.forloop.index`: `["l"; "forloop"; "index"]`. `unwrap_chain` then tried to look up `forloop` on the list value and fell into a fallback branch (`| v -> ...`) that recursively called `unwrap` with structurally identical state — infinite loop.

### Fix

- **Lexer (`liquid_parser/lexer.ml`)**: when a bracket's contents are not a numeric or quoted-string literal, tag the resulting piece with a sentinel (`\x00` prefix; dots inside the expression encoded as `\x01`) so the dynamic sub-expression survives the dot-split as a single piece.
- **`unwrap` (`liquid_syntax/values.ml`)**: pre-process `Var` pieces via a new `resolve_dynamic_pieces` step that strips the sentinel, recursively unwraps the sub-path against the current context, and substitutes the literal index/key (number/string) into the piece list. After resolution the existing `is_index` / `unwrap_chain` paths handle the lookup correctly.
- **`unwrap_chain`**: tightened the fallback so it (a) only re-enters for known method-style accessors (`first`/`last`/`size`), (b) handles numeric indexing on lists directly, and (c) returns `Nil` for unknown fields on non-objects instead of recursing.

This also enables `obj[var]` dynamic object key access as a bonus.

## #9: `{% liquid` (space between `%` and `liquid`) silently drops the block

`lex_block_token_chunk` matched the `liquid` tag with `RawText "liquid" :: StatementStart _`, which required `RawText` to equal exactly `"liquid"`. The block tokenizer accumulates non-token characters one-by-one, so `{% liquid` produced `RawText " liquid"` and never matched. The `LiquidStart` promotion never fired and the surrounding `LiquidStart :: RawText body :: StatementEnd` pattern in `lex_all_tokens` then failed too, so the whole block plus everything after it fell through and was silently dropped.

### Fix

Match any `RawText` whose stripped content equals `"liquid"`. Now `{%liquid`, `{% liquid`, `{%   liquid`, and `{%- liquid` all work uniformly.