### PR TITLE
Fix `and`/`or` with bare values (and echo of string literals)

### DIFF
--- a/liquid_parser/lexer.ml
+++ b/liquid_parser/lexer.ml
@@ -231,10 +231,8 @@ let lex_line_tokens text =
 let echo_to_expression tokens =
   let rec aux acc pool =
     match pool with
-    | LexValue (LexId [ "echo" ]) :: LexValue (LexString t) :: tl ->
-        aux (acc @ [ LexExpression [ LexText t ] ]) tl
-    | LexValue (LexId [ "echo" ]) :: LexValue (LexId id) :: tl ->
-        aux (acc @ [ LexExpression [ LexValue (LexId id) ] ]) tl
+    | LexValue (LexId [ "echo" ]) :: LexValue v :: tl ->
+        aux (acc @ [ LexExpression [ LexValue v ] ]) tl
     | hd :: tl -> aux (acc @ [ hd ]) tl
     | [] -> acc
   in

--- a/liquid_parser/test.ml
+++ b/liquid_parser/test.ml
@@ -20,31 +20,29 @@ let build_condition tokens =
   match tokens with
   | Else :: _ -> Always true
   | If :: statement | ElseIf :: statement | Unless :: statement ->
-      let rec aux acc pool =
-        match pool with
-        | [ LexValue a1 ] -> IsTruthy (lex_value_to_value a1)
-        | [ LexValue a1; Operator op1; LexValue b1 ] ->
-            lex_to_equation a1 op1 b1
-        | LexValue a1
-          :: Operator op1
-          :: LexValue b1
-          :: LexCombiner c
-          :: LexValue a2
-          :: Operator op2
-          :: LexValue b2
-          :: tl ->
-            let part_1 = lex_to_equation a1 op1 b1 in
-            let part_2 = lex_to_equation a2 op2 b2 in
-            let compound = combine_condition part_1 part_2 c in
-            aux compound tl
-        | LexCombiner c :: LexValue a1 :: Operator op1 :: LexValue b1 :: tl ->
-            let part_1 = lex_to_equation a1 op1 b1 in
-            let compound = combine_condition acc part_1 c in
-            aux compound tl
-        | [] -> acc
+      (* A condition is a sequence of terms joined by and/or combiners.
+         A term is either an equation (a == b) or a bare truthy value (a). *)
+      let parse_term = function
+        | LexValue a :: Operator op :: LexValue b :: tl ->
+            (lex_to_equation a op b, tl)
+        | LexValue a :: tl -> (IsTruthy (lex_value_to_value a), tl)
         | _ -> Failure "Invalid condition" |> raise
       in
-      let res = aux (Always true) statement in
+      let rec aux acc pool =
+        match pool with
+        | [] -> acc
+        | LexCombiner c :: tl ->
+            let term, rest = parse_term tl in
+            aux (combine_condition acc term c) rest
+        | _ -> Failure "Invalid condition" |> raise
+      in
+      let res =
+        match statement with
+        | [] -> Always true
+        | _ ->
+            let first, rest = parse_term statement in
+            aux first rest
+      in
       if is_unless then Not res else res
   | _ -> raise (Failure "Invalid token list")
 

--- a/test/test_interpreter.ml
+++ b/test/test_interpreter.ml
@@ -214,6 +214,56 @@ let test_not_with_condition () =
   let result = render_text ~settings "{% unless flag %}yes{% endunless %}" in
   check string "unless (not) operator" "yes" result
 
+(* Regression: `and`/`or` joining bare truthy values (not just equations).
+   Previously raised Failure("Invalid condition"). See issue #14. *)
+let test_and_bare_values () =
+  let context =
+    Ctx.empty |> Ctx.add "a" (Bool true) |> Ctx.add "b" (Bool false)
+  in
+  let settings = Settings.make ~context () in
+  let result =
+    render_text ~settings "{% if a and b %}both{% else %}not both{% endif %}"
+  in
+  check string "and with bare values" "not both" result
+
+let test_or_bare_values () =
+  let context =
+    Ctx.empty |> Ctx.add "a" (Bool true) |> Ctx.add "b" (Bool false)
+  in
+  let settings = Settings.make ~context () in
+  let result =
+    render_text ~settings "{% if a or b %}some{% else %}none{% endif %}"
+  in
+  check string "or with bare values" "some" result
+
+let test_and_bare_literals () =
+  let result =
+    render_text "{% if true and false %}both{% else %}not both{% endif %}"
+  in
+  check string "and with bare literals" "not both" result
+
+let test_and_mixed_bare_and_equation () =
+  let context = Ctx.empty |> Ctx.add "a" (Bool true) in
+  let settings = Settings.make ~context () in
+  let result =
+    render_text ~settings "{% if a == true and a %}yes{% else %}no{% endif %}"
+  in
+  check string "mixed bare value and equation" "yes" result
+
+let test_and_in_liquid_tag () =
+  (* The exact reproduction from issue #14. *)
+  let template =
+    "{% liquid\n\
+     assign a = true\n\
+     assign b = true\n\
+     if a and b\n\
+     echo \"both are true\"\n\
+     endif\n\
+     %}"
+  in
+  let result = render_text template in
+  check string "and inside liquid tag" "\n\n\nboth are true\n\n" result
+
 let test_complex_and_or () =
   let context =
     Ctx.empty |> Ctx.add "a" (Number 5.) |> Ctx.add "b" (Number 10.)
@@ -476,6 +526,22 @@ let test_liquid_tag_with_multiple_spaces () =
   let result = render_text template in
   check string "{%   liquid (multiple spaces)" "\nhello\nafter" result
 
+(* Regression: `echo` of a string literal previously leaked the internal
+   "*skip" sentinel instead of outputting the string. See issue #14. *)
+let test_echo_string_literal () =
+  let result = render_text "{% echo \"hello\" %}" in
+  check string "echo string literal" "hello" result
+
+let test_echo_number_literal () =
+  let result = render_text "{% echo 42 %}" in
+  check string "echo number literal" "42" result
+
+let test_echo_variable () =
+  let context = Ctx.empty |> Ctx.add "x" (String "world") in
+  let settings = Settings.make ~context () in
+  let result = render_text ~settings "{% echo x %}" in
+  check string "echo variable" "world" result
+
 let test_liquid_tag_with_trim_and_space () =
   let template =
     "prefix {%- liquid\nassign x = \"hello\"\necho x\n-%} after"
@@ -737,6 +803,12 @@ let suite =
     ; test_case "and operator" `Quick test_and_operator
     ; test_case "or operator" `Quick test_or_operator
     ; test_case "unless (not) operator" `Quick test_not_with_condition
+    ; test_case "and with bare values" `Quick test_and_bare_values
+    ; test_case "or with bare values" `Quick test_or_bare_values
+    ; test_case "and with bare literals" `Quick test_and_bare_literals
+    ; test_case "mixed bare and equation" `Quick
+        test_and_mixed_bare_and_equation
+    ; test_case "and inside liquid tag" `Quick test_and_in_liquid_tag
     ; test_case "complex and/or" `Quick test_complex_and_or
     ; test_case "nested conditions" `Quick test_nested_conditions
       (* Advanced capture tests *)
@@ -764,6 +836,10 @@ let suite =
     ; test_case "style basic" `Quick test_style_basic
     ; test_case "style with liquid" `Quick test_style_with_liquid
     ; test_case "style empty" `Quick test_style_empty
+      (* Echo tests *)
+    ; test_case "echo string literal" `Quick test_echo_string_literal
+    ; test_case "echo number literal" `Quick test_echo_number_literal
+    ; test_case "echo variable" `Quick test_echo_variable
       (* Liquid tag tests *)
     ; test_case "{%liquid (no space)" `Quick test_liquid_tag_no_space
     ; test_case "{% liquid (with space)" `Quick test_liquid_tag_with_space


### PR DESCRIPTION
Fixes #14.

## Problem

```liquid
{% liquid
assign a = true
assign b = false
if a and b
  echo "both are true"
endif
%}
```

This raised `Failure("Invalid condition")`.

## Root cause(s)

Two related parser bugs:

1. **Condition parsing** (`liquid_parser/test.ml`). `build_condition` only matched conditions composed of *equations* (`a == b`), via a set of hard-coded token-shape patterns. A bare truthy value joined by a combiner — `a and b`, `true or false` — matched none of them and fell through to `Failure("Invalid condition")`. (Equation+equation worked, which is why `x == 5 and y == 10` was fine.)

2. **Echo of string literals** (`liquid_parser/lexer.ml`). Separately, `echo "x"` was lexed to `LexExpression [LexText ...]`, which `expression_from_tokens` doesn't understand, so it emitted the internal `*skip` sentinel instead of the string. `echo <variable>` worked because it was wrapped as a `LexValue`. This matters here because the issue's example uses `echo "both are true"` — so even after fixing `and`, the body would have printed `*skip` when the condition was true.

## Fix

1. Rewrote `build_condition` as a small term parser: a *term* is either an equation (`a == b`) or a bare truthy value (`a`), and terms are joined left-to-right by `and`/`or`. The empty-condition case still yields `Always true` (preserving existing behavior).
2. In `echo_to_expression`, wrap any echo operand as a `LexValue`, fixing string and number echo while leaving variable echo unchanged.

## Tests

Added regression tests in `test/test_interpreter.ml`, including the exact reproduction from the issue:
- `and`/`or` with bare values and literals
- mixed bare value + equation
- `and` inside a `liquid` tag (issue repro)
- `echo` of string / number / variable

`dune test` — **270 tests run, all passing** (was 262; +8).