### PR TITLE
Fix excessive newlines emitted by {% liquid %} tags (#16)

### DIFF
--- a/liquid_parser/lexer.ml
+++ b/liquid_parser/lexer.ml
@@ -250,8 +250,12 @@ let lex_all_tokens (block_tokens : block_token list) =
       | ExpressionStart _ :: RawText body :: ExpressionEnd _ :: _ ->
           Next (acc @ [ LexExpression (lex_line_tokens body) ], index + 3)
       | LiquidStart _ :: RawText body :: StatementEnd _ :: _ ->
+          (* Inside a {% liquid %} tag, each line is its own statement.
+             Newlines act purely as statement separators (already captured
+             by the EOS emitted alongside them) and must not render as text. *)
           let liq =
             body |> Preprocessor.remove_liquid_comments |> lex_line_tokens
+            |> List.filter ~f:(function Newline -> false | _ -> true)
           in
           Next (acc @ liq, index + 3)
       | RawText other :: _ ->

--- a/test/test_interpreter.ml
+++ b/test/test_interpreter.ml
@@ -262,7 +262,7 @@ let test_and_in_liquid_tag () =
      %}"
   in
   let result = render_text template in
-  check string "and inside liquid tag" "\n\n\nboth are true\n\n" result
+  check string "and inside liquid tag" "both are true" result
 
 let test_complex_and_or () =
   let context =
@@ -510,21 +510,21 @@ let test_liquid_tag_no_space () =
     "{%liquid\nassign x = \"hello\"\necho x\n%}after"
   in
   let result = render_text template in
-  check string "{%liquid (no space)" "\nhello\nafter" result
+  check string "{%liquid (no space)" "helloafter" result
 
 let test_liquid_tag_with_space () =
   let template =
     "{% liquid\nassign x = \"hello\"\necho x\n%}after"
   in
   let result = render_text template in
-  check string "{% liquid (with space)" "\nhello\nafter" result
+  check string "{% liquid (with space)" "helloafter" result
 
 let test_liquid_tag_with_multiple_spaces () =
   let template =
     "{%   liquid\nassign x = \"hello\"\necho x\n%}after"
   in
   let result = render_text template in
-  check string "{%   liquid (multiple spaces)" "\nhello\nafter" result
+  check string "{%   liquid (multiple spaces)" "helloafter" result
 
 (* Regression: `echo` of a string literal previously leaked the internal
    "*skip" sentinel instead of outputting the string. See issue #14. *)
@@ -547,7 +547,7 @@ let test_liquid_tag_with_trim_and_space () =
     "prefix {%- liquid\nassign x = \"hello\"\necho x\n-%} after"
   in
   let result = render_text template in
-  check string "{%- liquid (trim + space)" "prefix\nhello\nafter" result
+  check string "{%- liquid (trim + space)" "prefixhelloafter" result
 
 (* Whitespace Control Tests *)
 


### PR DESCRIPTION
## Summary

Fixes #16. The `{% liquid %}` tag was emitting one stray newline per line break in the block (including blank lines), regardless of whitespace-control hyphens.

The exact reproduction from the issue now matches LiquidJS:

| Template | LiquidJS | liquid-ml (before) | liquid-ml (after) |
|---|---|---|---|
| `{% liquid ... %}` no trim | `testing\ntest2` | `testing\n\n\n\n\n\n\ntest2` | `testing\ntest2` ✓ |
| `{%- liquid ... -%}` with trim | `testingtest2` | `testing\n\n\n\n\ntest2` | `testingtest2` ✓ |

## Root cause

In `liquid_parser/lexer.ml`, the `{% liquid %}` body is lexed with `lex_line_tokens`, where each `\n` produces an `EOS; Newline` pair. The `EOS` correctly terminates each statement, but the `Newline` was later turned into literal `Text "\n"` output by the parser.

Inside a `{% liquid %}` block, newlines are statement separators, not content, so they should not render.

## Fix

Drop the redundant `Newline` tokens from the liquid tag body (statement separation is already handled by the accompanying `EOS`).

## Tests

- Updated 5 existing liquid-tag tests in `test/test_interpreter.ml` that had codified the buggy whitespace output (e.g. expecting `"\n\n\nboth are true\n\n"` instead of `"both are true"`).
- All 276 tests pass.