### PR TITLE
Fix variable ranges, for limit, if/for scoping, append coercion & string delimiters

### DIFF
--- a/liquid_interpreter/interpreter.ml
+++ b/liquid_interpreter/interpreter.ml
@@ -9,21 +9,6 @@ let nlit t = "*notifier_" ^ t
 let notifier t = Ctx.add (nlit t) (String (nlit t))
 let has_notifier t = Ctx.mem (nlit t)
 
-let save_state ctx =
-  let seq = Ctx.to_seq ctx in
-  let mapped = Stdlib.Seq.map (fun (id, _) -> id) seq in
-  let built = Stdlib.Seq.fold_left (fun acc curr -> acc @ [ curr ]) [] mapped in
-  built
-
-let rewind ctx ostate =
-  let cstate = save_state ctx in
-
-  let folder c_ctx key =
-    if contains ostate key then c_ctx else Ctx.remove key c_ctx
-  in
-
-  List.fold cstate ~init:ctx ~f:folder
-
 let list_from_ctx ctx =
   Ctx.to_seq ctx |> Stdlib.Seq.fold_left (fun acc curr -> acc @ [ curr ]) []
 
@@ -133,27 +118,29 @@ and interpret_else settings ctx str = function
   | None -> (ctx, str)
 
 and interpret_test settings ctx str ~cond ~body ~else_body =
-  let pre_state = save_state ctx in
-  let rctx, rstr =
-    if interpret_condition ctx cond then interpret settings ctx str body
-    else interpret_else settings ctx str else_body
-  in
-
-  let break_exists = has_notifier "break" rctx in
-  let continue_exists = has_notifier "continue" rctx in
-  let result_ctx = rewind rctx pre_state in
-  let result_ctx =
-    if break_exists then notifier "break" result_ctx else result_ctx
-  in
-  let result_ctx =
-    if continue_exists then notifier "continue" result_ctx else result_ctx
-  in
-
-  (result_ctx, rstr)
+  (* if/else/unless/case do NOT introduce a new scope in Liquid: variables
+     assigned inside a branch persist to the surrounding scope. We therefore
+     thread the branch's context straight through (it already carries any
+     break/continue notifiers set inside the branch). *)
+  if interpret_condition ctx cond then interpret settings ctx str body
+  else interpret_else settings ctx str else_body
 
 and interpret_for settings ctx str ~alias ~iterable ~params ~body ~else_body =
   let uiter = Values.unwrap ctx iterable in
-  let pre_state = save_state ctx in
+  (* When the loop finishes, variables assigned in the body must persist
+     (Liquid does not scope assigns), but the loop-local bindings must not:
+     restore `alias` and `forloop` to their pre-loop state, and clear any
+     break/continue notifiers so they don't leak past the loop. *)
+  let end_scope final =
+    let restore key c =
+      match Ctx.find_opt key ctx with
+      | Some v -> Ctx.add key v c
+      | None -> Ctx.remove key c
+    in
+    final |> restore alias |> restore Settings.forloop
+    |> Ctx.remove (nlit "break")
+    |> Ctx.remove (nlit "continue")
+  in
   let loop (acc_ctx, acc_str) curr ~last =
     (* TODO: Add forloop parent var *)
     let loop_ctx = Ctx.add alias curr acc_ctx in
@@ -162,7 +149,7 @@ and interpret_for settings ctx str ~alias ~iterable ~params ~body ~else_body =
         let inner_ctx, rendered = interpret_block settings loop_ctx "" b in
         let r_str = acc_str ^ rendered in
         if has_notifier "break" inner_ctx then
-          Done (rewind inner_ctx pre_state, acc_str)
+          Done (end_scope inner_ctx, acc_str)
         else if has_notifier "continue" inner_ctx then
           let find_int k =
             match Ctx.find Settings.forloop acc_ctx with
@@ -181,7 +168,7 @@ and interpret_for settings ctx str ~alias ~iterable ~params ~body ~else_body =
           (* Remove the continue notifier for the next iteration *)
           let next_ctx = Ctx.remove (nlit "continue") nacc in
 
-          if last then Forward (rewind next_ctx pre_state, r_str)
+          if last then Forward (end_scope next_ctx, r_str)
           else Forward (next_ctx, r_str)
         else
           let find_int k =
@@ -198,7 +185,7 @@ and interpret_for settings ctx str ~alias ~iterable ~params ~body ~else_body =
             Interpreter_objects.make_forloop_ctx inner_ctx index length
           in
 
-          if last then Forward (rewind nacc pre_state, r_str)
+          if last then Forward (end_scope nacc, r_str)
           else Forward (nacc, r_str)
     | _ -> raise (Failure "A body must be a block")
   in

--- a/liquid_parser/lexer.ml
+++ b/liquid_parser/lexer.ml
@@ -50,25 +50,32 @@ let lex_number text =
 let has_prefix_or_fail text prefix func =
   if starts_with text prefix then remove_prefix text prefix |> func else None
 
+(* A range bound is either a number literal or an identifier (variable), e.g.
+   both `(1..5)` and `(1..n)` / `(start..stop)` are valid. *)
+let lex_range_atom text =
+  match lex_digit_group text with
+  | "" ->
+      (* No '.' in the char class: it must not swallow the '..' separator. *)
+      let id_exp = ~/"^[a-zA-Z_][a-zA-Z0-9_]*" in
+      if Re2.matches id_exp text then
+        let lit = Re2.find_first_exn id_exp text in
+        Some (LexId [ lit ], remove_prefix text lit)
+      else None
+  | digits -> Some (LexNumber (Float.of_string digits), remove_prefix text digits)
+
 let lex_range text =
   let popen, pclose = ("(", ")") in
   let dotdot = ".." in
   let lex_first_group wo_paren =
-    match lex_digit_group wo_paren with
-    | "" -> None
-    | first_number ->
-        let after_first = remove_prefix wo_paren first_number in
+    match lex_range_atom wo_paren with
+    | None -> None
+    | Some (first, after_first) ->
         let lex_second_group wo_dot =
-          match lex_digit_group wo_dot with
-          | "" -> None
-          | second_number ->
-              let after_second = remove_prefix wo_dot second_number in
+          match lex_range_atom wo_dot with
+          | None -> None
+          | Some (second, after_second) ->
               if starts_with after_second pclose then
-                let range =
-                  LexValue
-                    (LexRange
-                       (Int.of_string first_number, Int.of_string second_number))
-                in
+                let range = LexValue (LexRange (first, second)) in
                 Some (range, remove_prefix after_second pclose)
               else None
         in
@@ -157,35 +164,69 @@ let lex_token text =
   in
   first_successful text lexers
 
-let lex_block_token_chunk (chunk2, chunk3) acc index =
+(* Are we currently between a block opener ({{ or {%) and its closer? *)
+let inside_after_token inside = function
+  | StatementStart _ | ExpressionStart _ | LiquidStart _ -> true
+  | StatementEnd _ | ExpressionEnd _ -> false
+  | _ -> inside
+
+let lex_block_token_chunk (chunk2, chunk3) (acc, inside) index =
   if is_block_token_whitespace_string chunk3 then
-    Next (acc @ [ block_token_of_string chunk3 ], index + String.length chunk3)
+    let tok = block_token_of_string chunk3 in
+    Next ((acc @ [ tok ], inside_after_token inside tok), index + String.length chunk3)
   else if is_block_token_string chunk2 then
-    Next (acc @ [ block_token_of_string chunk2 ], index + String.length chunk2)
+    let tok = block_token_of_string chunk2 in
+    Next ((acc @ [ tok ], inside_after_token inside tok), index + String.length chunk2)
   else
     match List.rev acc with
     | RawText tl :: StatementStart ws :: hds
       when String.equal (String.strip tl) "liquid" ->
-        Next (List.rev hds @ [ LiquidStart ws ], index + 1)
+        Next ((List.rev hds @ [ LiquidStart ws ], inside), index + 1)
     | RawText tl :: hds ->
-        Next (List.rev hds @ [ RawText (tl ^ first_letter chunk2) ], index + 1)
-    | _ -> Next (acc @ [ RawText (first_letter chunk2) ], index + 1)
+        Next ((List.rev hds @ [ RawText (tl ^ first_letter chunk2) ], inside), index + 1)
+    | _ -> Next ((acc @ [ RawText (first_letter chunk2) ], inside), index + 1)
 
 let lex_block_tokens text =
-  let folder acc index =
-    let curr = String.sub text ~pos:index ~len:(String.length text - index) in
+  let len = String.length text in
+  (* When inside a block, consume a quoted string literal verbatim so that any
+     {{ }} {% %} characters inside it are NOT mistaken for block delimiters. *)
+  let consume_quote index =
+    let q = text.[index] in
+    let rec go i =
+      if i >= len then i
+      else if Char.equal text.[i] '\\' && i + 1 < len then go (i + 2)
+      else if Char.equal text.[i] q then i + 1
+      else go (i + 1)
+    in
+    go (index + 1)
+  in
+  let append_raw acc s =
+    match List.rev acc with
+    | RawText tl :: hds -> List.rev hds @ [ RawText (tl ^ s) ]
+    | _ -> acc @ [ RawText s ]
+  in
+  let folder (acc, inside) index =
+    let curr = String.sub text ~pos:index ~len:(len - index) in
     if Preprocessor.is_raw curr then
       let raw_text = Preprocessor.until_end_raw curr in
       let raw_body = Preprocessor.trim_raw_tags raw_text in
-      Next (acc @ [ RawText raw_body ], index + String.length raw_text)
-    else if index + 3 < String.length text then
+      Next ((acc @ [ RawText raw_body ], inside), index + String.length raw_text)
+    else if
+      inside && index < len
+      && (Char.equal text.[index] '\'' || Char.equal text.[index] '"')
+    then
+      let endi = consume_quote index in
+      let span = String.sub text ~pos:index ~len:(endi - index) in
+      Next ((append_raw acc span, inside), endi)
+    else if index + 3 < len then
       let chunk2 = String.sub text ~pos:index ~len:2 in
       let chunk3 = String.sub text ~pos:index ~len:3 in
-      lex_block_token_chunk (chunk2, chunk3) acc index
-    else Stop acc
+      lex_block_token_chunk (chunk2, chunk3) (acc, inside) index
+    else Stop (acc, inside)
   in
 
-  unfold [] 0 folder
+  let toks, _ = unfold ([], false) 0 folder in
+  toks
 
 let apply_whitespace_control tokens =
   let is_trim_start = function

--- a/liquid_std/liquid_string.ml
+++ b/liquid_std/liquid_string.ml
@@ -5,9 +5,11 @@ open Tools
 open Helpers
 open Encoder
 
-let append _ = function
-  | String base :: String addition :: _ -> String (base ^ addition) |> ok
-  | other -> errc "append accepts 2 strings" other
+let append ctx = function
+  | base :: addition :: _ ->
+      String (Values.string_from_value ctx base ^ Values.string_from_value ctx addition)
+      |> ok
+  | other -> errc "append accepts 2 values" other
 
 let base64_decode _ = function
   | String s :: _ -> Base64.decode_exn s |> ok_str
@@ -115,9 +117,11 @@ let pluralize _ = function
       errc "pluralize accepts a number, a singular string and a plural string"
         other
 
-let prepend _ = function
-  | String base :: String addition :: _ -> addition ^ base |> ok_str
-  | other -> errc "prepend accepts 2 strings" other
+let prepend ctx = function
+  | base :: addition :: _ ->
+      Values.string_from_value ctx addition ^ Values.string_from_value ctx base
+      |> ok_str
+  | other -> errc "prepend accepts 2 values" other
 
 let remove _ = function
   | String haystack :: String needle :: _ ->

--- a/liquid_syntax/syntax.ml
+++ b/liquid_syntax/syntax.ml
@@ -32,6 +32,7 @@ type value =
   | List of value list
   | Date of Date.t
   | Object of liquid_object
+  | Range of value * value
   | Nil
 
 and liquid_object = value Object.t
@@ -63,6 +64,8 @@ and pp_value fmt = function
         (List.map l ~f:show_value |> String.concat ~sep:", ")
   | Date d -> pp_date fmt d
   | Object obj -> pp_liquid_object fmt obj
+  | Range (a, b) ->
+      Stdlib.Format.fprintf fmt "Range(%s..%s)" (show_value a) (show_value b)
   | Nil -> Stdlib.Format.fprintf fmt "Nil"
 
 and show_value = function
@@ -74,6 +77,7 @@ and show_value = function
       "List[" ^ (List.map l ~f:show_value |> String.concat ~sep:", ") ^ "]"
   | Date d -> show_date d
   | Object obj -> "Object{" ^ show_liquid_object obj ^ "}"
+  | Range (a, b) -> "Range(" ^ show_value a ^ ".." ^ show_value b ^ ")"
   | Nil -> "Nil"
 
 let pp_variable_context fmt ctx =
@@ -138,24 +142,27 @@ type ast =
   | Nothing
 [@@deriving show]
 
-let list_of_range = function
-  | LexRange (start, stop) -> List.range start (stop + 1)
-  | _ -> raise (Failure "This is not a range!")
+(* Build the concrete integer list for a resolved range (inclusive). *)
+let liq_list_from_bounds lo hi =
+  let lst = if hi >= lo then List.range lo (hi + 1) else [] in
+  List (List.map lst ~f:(fun n -> Number (Int.to_float n)))
 
-let liq_list_of_range r =
-  List (List.map (list_of_range r) ~f:(fun n -> Number (Int.to_float n)))
-
-let lex_value_to_value = function
+let rec lex_value_to_value = function
   | LexId id -> Var id
   | LexBool b -> Bool b
   | LexString s -> String s
   | LexNumber n -> Number n
-  | LexRange (st, sp) -> liq_list_of_range (LexRange (st, sp))
+  (* A range's bounds are kept as values and resolved at interpret time, so
+     that variable bounds like (1..n) work, not just integer literals. *)
+  | LexRange (lo, hi) -> Range (lex_value_to_value lo, lex_value_to_value hi)
   | LexNil -> Nil
   | LexBlank -> String ""
 
+(* Shopify's `for` has no implicit limit; only an explicit `limit:` caps it.
+   We use a very large sentinel so `min(len, limit)` is effectively unbounded
+   while avoiding any `limit - offset` overflow. *)
 let for_params_default =
-  { limit = 50; offset = 0; reved = false; cols = 10; is_tablerow = false }
+  { limit = Int.max_value / 2; offset = 0; reved = false; cols = 10; is_tablerow = false }
 
 type liquid_filter = variable_context -> value list -> (value, string) Result.t
 type liquid_filter_lookup = string -> liquid_filter option

--- a/liquid_syntax/tokens.ml
+++ b/liquid_syntax/tokens.ml
@@ -18,7 +18,7 @@ type lex_value =
   | LexString of string
   | LexNumber of float
   | LexId of string list
-  | LexRange of int * int
+  | LexRange of lex_value * lex_value
   | LexNil
   | LexBlank
 [@@deriving show]

--- a/liquid_syntax/values.ml
+++ b/liquid_syntax/values.ml
@@ -18,6 +18,16 @@ let rec unwrap ctx v =
   | Var id ->
       let id = resolve_dynamic_pieces ctx id in
       unwrap_id ctx id
+  | Range (a, b) ->
+      let to_int x =
+        match unwrap ctx x with
+        | Number n -> Some (Int.of_float n)
+        | String s -> ( try Some (Int.of_string (String.strip s)) with _ -> None)
+        | _ -> None
+      in
+      (match (to_int a, to_int b) with
+      | Some lo, Some hi -> liq_list_from_bounds lo hi
+      | _ -> List [])
   | other -> other
 
 and unwrap_id ctx id =
@@ -102,6 +112,7 @@ let rec string_from_value ctx = function
       if Float.round_down f = f then f |> Float.to_int |> Int.to_string
       else Float.to_string f
   | Var id -> string_from_value ctx (unwrap ctx (Var id))
+  | Range (a, b) -> string_from_value ctx (unwrap ctx (Range (a, b)))
   | Nil -> "nil"
   | List lst -> List.map lst ~f:(string_from_value ctx) |> join_by_comma
   | Object obj -> json_from_value ctx (Object obj)

--- a/test/test_bug_fixes.ml
+++ b/test/test_bug_fixes.ml
@@ -1,0 +1,117 @@
+open Alcotest
+open Liquid_ml
+open Liquid
+
+(* Regression tests for bugs fixed while building a self-hosting compiler.
+   See the project that motivated these (liquid-in-liquid). *)
+
+let r t = render_text t
+
+(* --- append / prepend coerce non-string arguments (Shopify behaviour) --- *)
+
+let test_append_number () =
+  check string "append number" "n=5" (r "{{ 'n=' | append: 5 }}")
+
+let test_append_chain () =
+  check string "append chain"
+    "12"
+    (r "{%- assign a = '' -%}{%- assign a = a | append: 1 | append: 2 -%}{{ a }}")
+
+let test_prepend_number () =
+  check string "prepend number" "7x" (r "{{ 'x' | prepend: 7 }}")
+
+(* --- `for` has no implicit limit (used to silently cap at 50) --- *)
+
+let test_for_no_default_limit () =
+  let out = r "{% for i in (1..60) %}.{% endfor %}" in
+  check int "for renders all 60 iterations" 60 (String.length out)
+
+(* --- variable ranges --- *)
+
+let test_range_literal () =
+  check string "literal range" "12345" (r "{% for i in (1..5) %}{{ i }}{% endfor %}")
+
+let test_range_var_stop () =
+  check string "(1..n)" "1234"
+    (r "{%- assign n = 4 -%}{% for i in (1..n) %}{{ i }}{% endfor %}")
+
+let test_range_var_both () =
+  check string "(a..b)" "3456"
+    (r
+       "{%- assign a = 3 -%}{%- assign b = 6 -%}{% for i in (a..b) %}{{ i }}{% \
+        endfor %}")
+
+let test_range_empty () =
+  check string "empty range when hi<lo" "[]"
+    (r "{%- assign n = 0 -%}[{% for i in (1..n) %}{{ i }}{% endfor %}]")
+
+(* --- delimiters inside string literals must not break the lexer --- *)
+
+let test_braces_in_string_assign () =
+  check string "{{ in a string" "{{x}}"
+    (r "{%- assign o = '{{x}}' -%}{{ o }}")
+
+let test_stmt_delims_in_string () =
+  check string "{% %} in a string" "[{% if %}]"
+    (r "{%- assign o = '{% if %}' -%}[{{ o }}]")
+
+let test_braces_in_expression_literal () =
+  check string "braces in expression literal" "{{x}}" (r "{{ '{{x}}' }}")
+
+let test_apostrophe_in_raw_text () =
+  check string "apostrophe in raw text" "it's a test x"
+    (r "it's a test {{ 'x' }}")
+
+(* --- if/for bodies do not scope assignments (Liquid semantics) --- *)
+
+let test_assign_in_if_persists () =
+  check string "assign in if persists" "5"
+    (r "{% if true %}{% assign x = 5 %}{% endif %}{{ x }}")
+
+let test_assign_in_else_persists () =
+  check string "assign in else persists" "7"
+    (r "{% if false %}a{% else %}{% assign y = 7 %}{% endif %}{{ y }}")
+
+let test_assign_in_for_persists () =
+  check string "assign in for persists after loop" "3"
+    (r "{% for i in (1..3) %}{% assign last = i %}{% endfor %}{{ last }}")
+
+let test_loop_var_not_leaked () =
+  check string "loop var does not leak" "[nil]"
+    (r "{% for i in (1..3) %}{% endfor %}[{{ i }}]")
+
+let test_break_does_not_leak () =
+  check string "break confined to inner loop" "1-1-"
+    (r
+       "{% for i in (1..2) %}{% for j in (1..3) %}{% if j == 2 %}{% break %}{% \
+        endif %}{{ j }}{% endfor %}-{% endfor %}")
+
+let test_nested_forloop_index () =
+  check string "nested forloop.index" "12|12|"
+    (r
+       "{% for i in (1..2) %}{% for j in (1..2) %}{{ forloop.index }}{% endfor \
+        %}|{% endfor %}")
+
+let suite =
+  ( "Bug Fix Regressions"
+  , [
+      test_case "append number" `Quick test_append_number
+    ; test_case "append chain" `Quick test_append_chain
+    ; test_case "prepend number" `Quick test_prepend_number
+    ; test_case "for no default limit" `Quick test_for_no_default_limit
+    ; test_case "range literal" `Quick test_range_literal
+    ; test_case "range (1..n)" `Quick test_range_var_stop
+    ; test_case "range (a..b)" `Quick test_range_var_both
+    ; test_case "range empty" `Quick test_range_empty
+    ; test_case "braces in string assign" `Quick test_braces_in_string_assign
+    ; test_case "stmt delims in string" `Quick test_stmt_delims_in_string
+    ; test_case "braces in expression literal" `Quick
+        test_braces_in_expression_literal
+    ; test_case "apostrophe in raw text" `Quick test_apostrophe_in_raw_text
+    ; test_case "assign in if persists" `Quick test_assign_in_if_persists
+    ; test_case "assign in else persists" `Quick test_assign_in_else_persists
+    ; test_case "assign in for persists" `Quick test_assign_in_for_persists
+    ; test_case "loop var not leaked" `Quick test_loop_var_not_leaked
+    ; test_case "break does not leak" `Quick test_break_does_not_leak
+    ; test_case "nested forloop.index" `Quick test_nested_forloop_index
+    ] )

--- a/test/test_runner.ml
+++ b/test/test_runner.ml
@@ -14,4 +14,5 @@ let () =
     ; Test_interpreter.suite
     ; Test_variables.suite
     ; Test_complex_templates.suite
+    ; Test_bug_fixes.suite
     ]


### PR DESCRIPTION
Several fixes that bring `liquid_ml` in line with the Ruby/Shopify Liquid
reference implementation. Each is covered by new regression tests in
`test/test_bug_fixes.ml`; the full suite (incl. the real Shopify theme
fixtures) passes — **294 tests**.

## What's fixed

### Variable ranges `(1..n)` / `(a..b)`
Previously only integer literals were accepted; a variable bound silently
produced an empty loop. `LexRange` now carries two `lex_value`s, and a new
deferred `Range of value * value` is resolved at interpret time in
`Values.unwrap`. Descending ranges yield an empty list (matches Ruby).

```liquid
{%- assign n = 4 -%}{% for i in (1..n) %}{{ i }}{% endfor %}   => 1234
```

### `for` had an implicit limit of 50
Ruby's `for` has no default limit; only an explicit `limit:` caps it. The
default is now effectively unbounded.

### `if`/`for` no longer discard in-body assignments
This matched neither Ruby nor Shopify: a variable assigned inside an
`if`/`for` body was deleted when the block ended. Ruby writes `assign` to the
root scope, so those values persist.

```liquid
{% if true %}{% assign x = 5 %}{% endif %}{{ x }}                  => 5
{% for i in (1..3) %}{% assign last = i %}{% endfor %}{{ last }}    => 3
```

The loop variable and `forloop` are still scoped to the loop (restored to
their pre-loop state afterwards), and `break`/`continue` no longer leak past
the loop. Verified with nested loops and shadowed loop variables
(`{%- assign i='before' -%}{% for i in (1..3) %}{% endfor %}{{ i }}` => `before`).

### `append` / `prepend` coerce non-string arguments
Ruby coerces operands to strings. These now stringify the same way `{{ }}`
output does.

```liquid
{{ 'n=' | append: 5 }}    => n=5
```

### Lexer: delimiters inside string literals
The block-token scanner is now quote-aware: `{{`, `}}`, `{%`, `%}` inside a
string literal in a tag are no longer mistaken for block delimiters. Raw text
is unaffected (quotes there are not treated specially), so well-formed
templates are unchanged — this only makes the lexer accept a superset.

```liquid
{% assign o = '{% raw %}' %}{{ o }}   => {% raw %}
```

## Compatibility note
liquid_ml renders `nil`/undefined as the literal `"nil"` (Ruby renders `""`).
That is pre-existing and unchanged here, but `append`/`prepend` now surface it
(`{{ missing | append: 'y' }}` => `"nily"`). I kept `append` consistent with
`{{ }}` interpolation, so fixing the global `nil`→`""` rendering later would
make `append` Ruby-correct automatically. Happy to do that in a follow-up.

## Files
- `liquid_syntax/tokens.ml`, `liquid_syntax/syntax.ml`, `liquid_syntax/values.ml` — `Range` value + resolution, default `for` limit
- `liquid_parser/lexer.ml` — range-bound atoms, quote-aware block scanner
- `liquid_std/liquid_string.ml` — `append`/`prepend` coercion
- `liquid_interpreter/interpreter.ml` — if/for scoping
- `test/test_bug_fixes.ml` (+ `test/test_runner.ml`) — 18 regression tests